### PR TITLE
fix: index counting in Codification class

### DIFF
--- a/Sources/Accord.Statistics/Filters/Codification`1.cs
+++ b/Sources/Accord.Statistics/Filters/Codification`1.cs
@@ -748,7 +748,7 @@ namespace Accord.Statistics.Filters
                             try { value = map[label]; }
                             catch
                             {
-                                value = map.Values.Count + 1;
+                                value = map.Values.Count;
                                 map[label] = value;
                             }
 

--- a/nuget_version.json
+++ b/nuget_version.json
@@ -1,6 +1,6 @@
 {
 	"major": "8",
 	"minor": "1",
-	"patch": "0",
+	"patch": "1",
 	"type": ""
 }


### PR DESCRIPTION
When ProcessFilter is called via the Apply method, adding entries have been skipping a index because `Count` + 1 was applied instead of just `Count`.